### PR TITLE
restructure macros so the server.foo problems goes away

### DIFF
--- a/src/server/foo.clj
+++ b/src/server/foo.clj
@@ -1,0 +1,5 @@
+
+(ns server.foo)
+
+(defmacro some-macro [x]
+  `(bar ~x))

--- a/src/server/foo.cljs
+++ b/src/server/foo.cljs
@@ -1,5 +1,6 @@
 
-(ns server.foo)
+(ns server.foo
+  (:require-macros [server.foo]))
 
 (defn bar [x]
   (println "This is bar! Try:" x))

--- a/src/server/macros.cljc
+++ b/src/server/macros.cljc
@@ -1,6 +1,0 @@
-
-(ns server.macros
-  (:require [server.foo :refer [bar]]))
-
-(defmacro some-macro [x]
-  `(bar ~x))

--- a/src/server/main.cljs
+++ b/src/server/main.cljs
@@ -1,9 +1,6 @@
 
 (ns server.main
-  (:require-macros [server.macros :refer [some-macro]])
-  (:require [server.foo]))
+  (:require [server.foo :refer (some-macro)]))
 
-; server.foo is required... or compiler will warn
-
-(defn main! []
+(defn main []
   (some-macro "Hello!"))


### PR DESCRIPTION
I like keeping macros in `.clj` files with an additional `.cljs` file. The `.cljs` file does a `:require-macros` to the `.clj` file. This allows all other namespaces to just directly use the macros without using`:require-macros` themselves.

You can also combine the the two files into one by using `.cljc` but I prefer not doing that since you'll need some reader conditionals.